### PR TITLE
Fix Build-All-Platforms workflow for Windows and add release job

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -94,7 +94,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           tag_name: ${{ github.ref }}
-          name: Release ${{ github.ref }}
+          name: ${{ github.ref_name }}
           files: |
             ./artifacts/*.exe
             ./artifacts/*.bin

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -19,7 +19,7 @@ jobs:
 #        os: [macos-latest, ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
-    
+
     steps:
       # Check-out repository
       - uses: actions/checkout@v4
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+          python-version: '3.8' # Version range or exact version of a Python version to use, using SemVer's version range syntax
           architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
           cache: 'pip'
           cache-dependency-path: |
@@ -43,7 +43,7 @@ jobs:
           onefile: true
           access-token: ${{ secrets.NUITKA_COMMERCIAL_ACCESS_TOKEN }}
           # macos-create-app-bundle: ${{ runner.os == 'macOS' }}
-          
+
       # Uploads artifacts
       - name: "Upload Artifacts"
         uses: actions/upload-artifact@v3

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -88,6 +88,10 @@ jobs:
       - name: List files after download
         run: ls -R ./artifacts
 
+      # Rename Windows artifact to a suitable name
+      - name: Rename Windows artifact
+        run: mv ./artifacts/run.exe ./artifacts/RocksmithServant-${{ github.ref_name }}.exe
+
       # Create a GitHub release using softprops/action-gh-release
       - name: Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -5,10 +5,11 @@ on:
   # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
     branches: ["main"]
+    tags:      # Added to trigger the workflow on version tags
+      - 'v*'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-
 
 jobs:
   build:
@@ -32,10 +33,12 @@ jobs:
           cache: 'pip'
           cache-dependency-path: |
             **/requirements*.txt
+
       # Install dependencies
       - name: Install Dependencies
         run: |
           pip install -r requirements.txt
+
       # Build python script into a stand-alone exe
       - uses: jimkring/python-script-to-exe@v0.2.0
         with:
@@ -53,3 +56,48 @@ jobs:
             build/*.exe
             build/*.bin
             build/*.app/**/*
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')  # Ensures this job runs only for version tags
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Download artifacts from previous build steps
+      - name: Download Windows Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: Windows Build
+          path: ./artifacts
+
+#      - name: Download macOS Artifact
+#        uses: actions/download-artifact@v4
+#        with:
+#          name: macos-latest Build
+#          path: ./artifacts
+#
+#      - name: Download Linux Artifact
+#        uses: actions/download-artifact@v4
+#        with:
+#          name: ubuntu-latest Build
+#          path: ./artifacts
+
+      # Log files after download
+      - name: List files after download
+        run: ls -R ./artifacts
+
+      # Create a GitHub release using softprops/action-gh-release
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          tag_name: ${{ github.ref }}
+          name: Release ${{ github.ref }}
+          files: |
+            ./artifacts/*.exe
+            ./artifacts/*.bin
+            ./artifacts/*.app
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+          python-version: '3.10' # Version range or exact version of a Python version to use, using SemVer's version range syntax
           architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
           cache: 'pip'
           cache-dependency-path: |

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -46,7 +46,7 @@ jobs:
 
       # Uploads artifacts
       - name: "Upload Artifacts"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ runner.os }} Build
           path: |


### PR DESCRIPTION
The Build-All-Platforms workflow was failing because Nuitka does not support Python 3.11. (See error message: https://github.com/kozaka-tv/Rocksmith-Servant/actions/runs/9120235112/job/25077226556#step:5:110) After downgrading Python to 3.10, the workflow ends with success in the case of Windows. Also, the upload-artifacts action is upgraded to the new version, since older versions are getting deprecated. Adding release job for Windows too. If a tag starting with "v" is pushed to the main branch, the release job runs too. secret.GITHUB_TOKEN is an access token generated automatically by GitHub for the workflow.